### PR TITLE
BUG: fix incorrect day-of-week after passing negative value

### DIFF
--- a/packages/vega-functions/src/format.js
+++ b/packages/vega-functions/src/format.js
@@ -44,6 +44,7 @@ var dateObj = new Date(2000, 0, 1);
 
 function time(month, day, specifier) {
   if (!Number.isInteger(month) || !Number.isInteger(day)) return '';
+  dateObj.setYear(2000);
   dateObj.setMonth(month);
   dateObj.setDate(day);
   return timeFormat(dateObj, specifier);


### PR DESCRIPTION
The issue is that setting a negative day or month changes the year value, which is then used in subsequent calls. This means that once a negative number is passed to this function, subsequent calls return the wrong results. The remedy is to re-set the year each time the function is called.

Example of this bug: [vega editor](https://vega.github.io/editor/#/url/vega-lite/N4KABGBEAmCGAutIC4yghSA3WAbArgKYDOKYA2uBhMDLAJ5kAMAvgDRXW1yOoCM7Thm4MyAWgBMg6jTq8wrDjLRyyAoQF0q0qPABOsAHbEAZgHs9AWzKUukAMZ57+XAkJk5AMQuWEACkkASkg2KFhSVC8fBEgWKg0lKF89AGsPAAczAEtDeBCqSEJDezNoHIBzMnQMSAAPKsgTLMJcaA8eEN16dPdIgEd8I3gsxGGsdx1MeVomlrbInm8rGNDIeG7eqEMzSxy8WO0QOKA)